### PR TITLE
Added support for new CIGAR characters, may need to be re-visited again

### DIFF
--- a/general/CigarRoller.cpp
+++ b/general/CigarRoller.cpp
@@ -112,6 +112,14 @@ void CigarRoller::Add(char operation, int count)
         case 'P':
             Add(pad, count);
             break;
+        case 7:
+        case '=':
+            Add(match, count);
+            break;
+        case 8:
+        case 'X':
+            Add(match, count);
+            break;
         default:
             // Hmmm... what to do?
             std::cerr << "ERROR "


### PR DESCRIPTION
This quick fix is to improve compatibility with newer (v1.4-r985) samtools

ERROR (CigarRoller.cpp:118): Parsing CIGAR - invalid character found with parameter  and [number]

handles both '=' and 'X' characters as 'match' which seems to be ok
according to samtools specs,
but should be using a better handling in a future
