### PR TITLE
Various bugs

### DIFF
--- a/general/StringBasics.cpp
+++ b/general/StringBasics.cpp
@@ -741,7 +741,7 @@ int String::ReadLine(IFILE & f)
 
     while ( ((ch = f->ifgetc()) != EOF) && (ch != '\n'))
     {
-      if (ptr == endBuffer)
+      if (ptr >= endBuffer - 1)
         {
             // resize: 1 byte for the next character, 1 byte
             //  for the NUL at the end.
@@ -753,18 +753,8 @@ int String::ReadLine(IFILE & f)
         *ptr++ = ch;
         len++;
     }
-    // (zhanxw): ptr == endBuffer may happen,
-    // so need to check again.
-    if (ptr == endBuffer)
-    {
-      // resize: 1 byte for the next character, 1 byte
-      //  for the NUL at the end.
-      Grow(len + 2);
-      endBuffer = buffer + size;
-      ptr = buffer + len;
-    }
+
     // NB: assumes that buffer is always allocated.
-    // (zhanxw) I think assumption may not hold, so add above codes
     buffer[len] = 0;
 
     if ((ch == EOF) && (len == 0))


### PR DESCRIPTION
Hi, I'm working with Christian Fuchsberger on minimac.
I've discovered a couple of bugs while working with libStatGen 1.0.8 which I re-applied here.
- NewString/Grow always allocate short buffers. With towards-zero rounding, the new buffer size is always short of at least "alloc" bytes.
- Readline had an off-by-one overflow, which was fixed. I believe the current fix is saner.
