### PR TITLE
Fix build with gcc-13

### DIFF
--- a/bam/GenericSamInterface.h
+++ b/bam/GenericSamInterface.h
@@ -25,6 +25,7 @@
 #include <htslib/sam.h>
 #include <htslib/cram.h>
 
+#include <cstdint>
 
 
 class GenericSamInterface


### PR DESCRIPTION
The new compiler version `gcc-13` stops including the `<cstdint>` header by default (see [here](https://github.com/llvm/llvm-project/issues/55711) and [here](https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=6f038efd93593da6e661b829d1bd3877e75550f1)) which leads to an error when trying to build libStatGen.

```
g++  --std=c++11 -I$SRC_DIR/cget/include -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/raremetal-4.15.1 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix   -fopenmp -g  -I../include -I.   -D__ZLIB_AVAILABLE__ -D_FILE_OFFSET_BITS=64 -D__STDC_LIMIT_MACROS  -o obj/SamFile.o -c SamFile.cpp -DVERSION="\"1.0.0\""
In file included from SamRecord.h:24,
                 from SamFile.h:24,
                 from SamFile.cpp:18:
../include/GenomeSequence.h:99:7: warning: ‘GenomeSequence’ declared with greater visibility than its base ‘MemoryMapArray<unsigned int, unsigned int, 460927905, 20100401, PackedAccess_4Bit<char*>, PackedAssign_4Bit<char*>, Packed4BitElementCount2Bytes, genomeSequenceMmapHeader>’ [-Wattributes]
   99 | class GenomeSequence : public genomeSequenceArray
      |       ^~~~~~~~~~~~~~
In file included from SamFile.h:25:
GenericSamInterface.h:40:57: error: ‘std::int32_t’ has not been declared
   40 |     bool setReadSection(const char*const ref_name, std::int32_t beg = 0, std::int32_t end = INT_MAX);
      |                                                         ^~~~~~~
GenericSamInterface.h:40:79: error: ‘std::int32_t’ has not been declared
   40 |     bool setReadSection(const char*const ref_name, std::int32_t beg = 0, std::int32_t end = INT_MAX);
      |                                                                               ^~~~~~~
GenericSamInterface.h:41:30: error: ‘std::int32_t’ has not been declared
   41 |     bool setReadSection(std::int32_t ref_id, std::int32_t beg = 0, std::int32_t end = INT_MAX);
      |                              ^~~~~~~
GenericSamInterface.h:41:51: error: ‘std::int32_t’ has not been declared
   41 |     bool setReadSection(std::int32_t ref_id, std::int32_t beg = 0, std::int32_t end = INT_MAX);
      |                                                   ^~~~~~~
GenericSamInterface.h:41:73: error: ‘std::int32_t’ has not been declared
   41 |     bool setReadSection(std::int32_t ref_id, std::int32_t beg = 0, std::int32_t end = INT_MAX);
      |                                                                         ^~~~~~~
SamFile.cpp: In member function ‘bool SamFile::SetReadSection(const char*, int32_t, int32_t, bool)’:
SamFile.cpp:796:98: error: ‘uint32_t’ is not a member of ‘std’; did you mean ‘wint_t’?
  796 |     return(myInterfacePtr->setReadSection(refName, (start == -1 ? 0 : start), (end == -1 ? (std::uint32_t)-1 : end)));
      |                                                                                                  ^~~~~~~~
      |                                                                                                  wint_t
```

This patch fixes the error.



